### PR TITLE
Add tests for Alert API

### DIFF
--- a/RNTester/e2e/__tests__/Alert-test.js
+++ b/RNTester/e2e/__tests__/Alert-test.js
@@ -20,7 +20,7 @@ describe('Alert', () => {
     await element(by.label('Back')).tap();
   });
 
-  it('Alert with message and default button', async () => {
+  it('should show alert dialog with message and default button', async () => {
     const alertMessage =
       'Credibly reintermediate next-generation potentialities after goal-oriented ' +
       'catalysts for change. Dynamically revolutionize.';
@@ -31,7 +31,7 @@ describe('Alert', () => {
     await element(by.text('OK')).tap();
   });
 
-  it('Alert with three buttons', async () => {
+  it('should show alert dialog with three buttons', async () => {
     await openExampleWithTitle('Alerts');
     await element(by.id('alert-with-three-buttons')).tap();
     await expect(element(by.text('Alert Title'))).toBeVisible();

--- a/RNTester/e2e/__tests__/Alert-test.js
+++ b/RNTester/e2e/__tests__/Alert-test.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+/* global device, element, by, expect, waitFor */
+const {openExampleWithTitle} = require('../e2e-helpers');
+
+describe('Alert', () => {
+  beforeAll(async () => {
+    await element(by.id('explorer_search')).replaceText('Alert');
+    await element(by.label('Alert')).tap();
+  });
+
+  afterAll(async () => {
+    await element(by.label('Back')).tap();
+  });
+
+  it('Alert with message and default button', async () => {
+    const alertMessage =
+      'Credibly reintermediate next-generation potentialities after goal-oriented ' +
+      'catalysts for change. Dynamically revolutionize.';
+
+    await openExampleWithTitle('Alerts');
+    await element(by.id('alert-with-message-and-default-button')).tap();
+    await expect(element(by.text(alertMessage))).toBeVisible();
+    await element(by.text('OK')).tap();
+  });
+
+  it('Alert with three buttons', async () => {
+    await openExampleWithTitle('Alerts');
+    await element(by.id('alert-with-three-buttons')).tap();
+    await expect(element(by.text('Alert Title'))).toBeVisible();
+    await expect(element(by.text('Foo'))).toBeVisible();
+    await expect(element(by.text('Bar'))).toBeVisible();
+    await expect(element(by.text('Baz'))).toBeVisible();
+    await element(by.text('Foo')).tap();
+  });
+
+  // it('Alert that cannot be dismissed', async () => {
+  //   await openExampleWithTitle('Alerts');
+  //   await element(by.id('alert-with-that-cannot-be-dismissed')).tap();
+  //   await expect(element(by.text('Alert Title'))).toBeVisible();
+  //   await element(by.text('OK')).tap();
+  //   await expect(element(by.text('Alert Title'))).toBeVisible();
+  // });
+});

--- a/RNTester/e2e/__tests__/Alert-test.js
+++ b/RNTester/e2e/__tests__/Alert-test.js
@@ -40,12 +40,4 @@ describe('Alert', () => {
     await expect(element(by.text('Baz'))).toBeVisible();
     await element(by.text('Foo')).tap();
   });
-
-  // it('Alert that cannot be dismissed', async () => {
-  //   await openExampleWithTitle('Alerts');
-  //   await element(by.id('alert-with-that-cannot-be-dismissed')).tap();
-  //   await expect(element(by.text('Alert Title'))).toBeVisible();
-  //   await element(by.text('OK')).tap();
-  //   await expect(element(by.text('Alert Title'))).toBeVisible();
-  // });
 });

--- a/RNTester/js/examples/Alert/AlertExample.js
+++ b/RNTester/js/examples/Alert/AlertExample.js
@@ -35,6 +35,7 @@ class SimpleAlertExampleBlock extends React.Component<Props> {
     return (
       <View>
         <TouchableHighlight
+          testID="alert-with-message-and-default-button"
           style={styles.wrapper}
           onPress={() => Alert.alert('Alert Title', alertMessage)}>
           <View style={styles.button}>
@@ -65,6 +66,7 @@ class SimpleAlertExampleBlock extends React.Component<Props> {
           </View>
         </TouchableHighlight>
         <TouchableHighlight
+          testID="alert-with-three-buttons"
           style={styles.wrapper}
           onPress={() =>
             Alert.alert('Alert Title', null, [
@@ -94,6 +96,7 @@ class SimpleAlertExampleBlock extends React.Component<Props> {
           </View>
         </TouchableHighlight>
         <TouchableHighlight
+          testID="alert-with-that-cannot-be-dismissed"
           style={styles.wrapper}
           onPress={() =>
             Alert.alert(

--- a/RNTester/js/examples/Alert/AlertExample.js
+++ b/RNTester/js/examples/Alert/AlertExample.js
@@ -96,7 +96,6 @@ class SimpleAlertExampleBlock extends React.Component<Props> {
           </View>
         </TouchableHighlight>
         <TouchableHighlight
-          testID="alert-with-that-cannot-be-dismissed"
           style={styles.wrapper}
           onPress={() =>
             Alert.alert(


### PR DESCRIPTION
## Summary
Fixes #3 

## Changelog
Add e2e tests for Alert API. 

[IOS] [Added] - e2e test for the Alert API

## Test Plan
On running the following commands

```
detox build -c ios.sim.debug
detox test -c ios.sim.debug Alert-test.js
```

You will get the following output - 

<img width="1178" alt="Screenshot 2020-06-11 at 2 16 21 PM" src="https://user-images.githubusercontent.com/22813027/84364760-220c0280-abee-11ea-87d3-2bd5df771b61.png">






