### PR TITLE
Add E2E tests for InputAccessoryView

### DIFF
--- a/RNTester/e2e/__tests__/InputAccessoryView-test.js
+++ b/RNTester/e2e/__tests__/InputAccessoryView-test.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+react_native
+ * @format
+ */
+
+/* global device, element, by, expect */
+const {openComponentWithLabel} = require('../e2e-helpers');
+
+describe('InputAccessoryView', () => {
+  beforeAll(async () => {
+    await device.reloadReactNative();
+    await openComponentWithLabel(
+      '<InputAccessoryView>',
+      '<InputAccessoryView> Example showing how to use an InputAccessoryView to build an iMessage-like sticky text input',
+    );
+  });
+
+  it('Send button should show alert on press', async () => {
+    await element(by.id('input-accessory-send-button')).tap();
+    await expect(element(by.text('You tapped the button!'))).toBeVisible();
+  });
+});

--- a/RNTester/js/examples/InputAccessoryView/InputAccessoryViewExample.js
+++ b/RNTester/js/examples/InputAccessoryView/InputAccessoryViewExample.js
@@ -53,6 +53,7 @@ class TextInputBar extends React.PureComponent<TextInputProps, TextInputState> {
           onPress={() => {
             Alert.alert('You tapped the button!');
           }}
+          testID="input-accessory-send-button"
           title="Send"
         />
       </View>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Fixes #7  
Added E2E tests for the InputAccessoryView component.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[IOS] [Added] - Integration test for the pressable component

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

On running the following commands

```
detox build -c ios.sim.debug
detox test -c ios.sim.debug
```


The output is as shown below:


```
=== BUILD TARGET Flipper-RSocket OF PROJECT Pods WITH CONFIGURATION Debug ===
warning: no rule to process file '/Users/sakshijethi/Desktop/mlh-fellowship-react-native/react-native/RNTester/Pods/Flipper-RSocket/rsocket/benchmarks/CMakeLists.txt' of type text for architecture x86_64
warning: no rule to process file '/Users/sakshijethi/Desktop/mlh-fellowship-react-native/react-native/RNTester/Pods/Flipper-RSocket/rsocket/benchmarks/README.md' of type net.daringfireball.markdown for architecture x86_64
warning: no rule to process file '/Users/sakshijethi/Desktop/mlh-fellowship-react-native/react-native/RNTester/Pods/Flipper-RSocket/rsocket/README.md' of type net.daringfireball.markdown for architecture x86_64
detox[49276] INFO:  [test.js] configuration="ios.sim.debug" reportSpecs=true useCustomLogger=true DETOX_START_TIMESTAMP=1591901151922 node_modules/.bin/jest --config RNTester/e2e/config.json '--testNamePattern=^((?!:android:).)*$' --maxWorkers 1 "e2e"
detox[49277] INFO:  [DetoxServer.js] server listening on localhost:59406...
detox[49277] INFO:  [AppleSimUtils.js] com.facebook.react.uiapp launched. To watch simulator logs, run:
        /usr/bin/xcrun simctl spawn 822F3487-EBAD-4652-A225-6EE20D894605 log stream --level debug --style compact --predicate 'process == "RNTester"'
 PASS  RNTester/e2e/__tests__/Touchable-test.js (14.348 s)
  Touchable
    ✓ Touchable Highlight should be tappable (1553 ms)
    ✓ Touchable Without Feedback should be tappable (1038 ms)
    ✓ Text should be tappable (1031 ms)

detox[49277] INFO:  [DetoxServer.js] server listening on localhost:59443...
detox[49277] INFO:  [AppleSimUtils.js] com.facebook.react.uiapp launched. To watch simulator logs, run:
        /usr/bin/xcrun simctl spawn 822F3487-EBAD-4652-A225-6EE20D894605 log stream --level debug --style compact --predicate 'process == "RNTester"'
 PASS  RNTester/e2e/__tests__/TextInput-test.js (21.3 s)
  TextInput
    ✓ Live rewrite with spaces should replace spaces and enforce max length (2966 ms)
    ✓ Live rewrite with no spaces should remove spaces (3062 ms)
    ✓ Live rewrite with clear should remove spaces and clear (3506 ms)

detox[49277] INFO:  [DetoxServer.js] server listening on localhost:59496...
detox[49277] INFO:  [AppleSimUtils.js] com.facebook.react.uiapp launched. To watch simulator logs, run:
        /usr/bin/xcrun simctl spawn 822F3487-EBAD-4652-A225-6EE20D894605 log stream --level debug --style compact --predicate 'process == "RNTester"'
 PASS  RNTester/e2e/__tests__/DatePickerIOS-test.js (19.887 s)
  DatePickerIOS
    ✓ Should change indicator with datetime picker (3706 ms)
    ✓ Should change indicator with date-only picker (5734 ms)

detox[49277] INFO:  [DetoxServer.js] server listening on localhost:59541...
detox[49277] INFO:  [AppleSimUtils.js] com.facebook.react.uiapp launched. To watch simulator logs, run:
        /usr/bin/xcrun simctl spawn 822F3487-EBAD-4652-A225-6EE20D894605 log stream --level debug --style compact --predicate 'process == "RNTester"'
 PASS  RNTester/e2e/__tests__/Button-test.js (16.616 s)
  Button
    ✓ Simple button should be tappable (1726 ms)
    ✓ Adjusted color button should be tappable (1489 ms)
    ✓ Two buttons with JustifyContent:'space-between' should be tappable (2902 ms)
    ✓ Disabled button should not interact (542 ms)

detox[49277] INFO:  [DetoxServer.js] server listening on localhost:59584...
detox[49277] INFO:  [AppleSimUtils.js] com.facebook.react.uiapp launched. To watch simulator logs, run:
        /usr/bin/xcrun simctl spawn 822F3487-EBAD-4652-A225-6EE20D894605 log stream --level debug --style compact --predicate 'process == "RNTester"'
 PASS  RNTester/e2e/__tests__/Picker-test.js (10.008 s)
  Picker
    ✓ should be selectable by ID (159 ms)

detox[49277] INFO:  [DetoxServer.js] server listening on localhost:59617...
detox[49277] INFO:  [AppleSimUtils.js] com.facebook.react.uiapp launched. To watch simulator logs, run:
        /usr/bin/xcrun simctl spawn 822F3487-EBAD-4652-A225-6EE20D894605 log stream --level debug --style compact --predicate 'process == "RNTester"'
 PASS  RNTester/e2e/__tests__/InputAccessoryView-test.js (11.277 s)
  InputAccessoryView
    ✓ Send button should show alert on press (931 ms)

Test Suites: 6 passed, 6 total
Tests:       14 passed, 14 total
Snapshots:   0 total
Time:        93.543 s, estimated 124 s
Ran all test suites matching /e2e/i with tests matching "^((?!:android:).)*$"
```
