### PR TITLE
Fix alert screen crash in android in RNTester app (#21)

### DIFF
--- a/RNTester/js/examples/Alert/AlertExample.js
+++ b/RNTester/js/examples/Alert/AlertExample.js
@@ -18,8 +18,6 @@ const {
   View,
 } = require('react-native');
 
-const RNTesterBlock = require('../../components/RNTesterBlock');
-
 // corporate ipsum > lorem ipsum
 const alertMessage =
   'Credibly reintermediate next-generation potentialities after goal-oriented ' +
@@ -125,22 +123,6 @@ class SimpleAlertExampleBlock extends React.Component<Props> {
   }
 }
 
-class AlertExample extends React.Component {
-  static title = 'Alert';
-
-  static description =
-    'Alerts display a concise and informative message ' +
-    'and prompt the user to make a decision.';
-
-  render() {
-    return (
-      <RNTesterBlock title={'Alert'}>
-        <SimpleAlertExampleBlock />
-      </RNTesterBlock>
-    );
-  }
-}
-
 const styles = StyleSheet.create({
   wrapper: {
     borderRadius: 5,
@@ -152,7 +134,17 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = {
-  AlertExample,
-  SimpleAlertExampleBlock,
-};
+exports.title = 'Alert';
+exports.description =
+  'Alerts display a concise and informative message ' +
+  'and prompt the user to make a decision.';
+exports.examples = [
+  {
+    title: 'Alerts',
+    render(): React.Node {
+      return <SimpleAlertExampleBlock />;
+    },
+  },
+];
+
+exports.SimpleAlertExampleBlock = SimpleAlertExampleBlock;

--- a/RNTester/js/utils/RNTesterList.android.js
+++ b/RNTester/js/utils/RNTesterList.android.js
@@ -122,7 +122,7 @@ const APIExamples: Array<RNTesterExample> = [
   },
   {
     key: 'AlertExample',
-    module: require('../examples/Alert/AlertExample').AlertExample,
+    module: require('../examples/Alert/AlertExample'),
   },
   {
     key: 'AnimatedExample',


### PR DESCRIPTION
## Summary

fixes #21 

## Changelog

Before: 

![image](https://user-images.githubusercontent.com/22813027/84471321-ba63bf00-aca2-11ea-92c0-3b43a8bdd28a.png)


After: 

<img width="305" alt="Screenshot 2020-06-12 at 11 49 31 AM" src="https://user-images.githubusercontent.com/22813027/84471351-c8b1db00-aca2-11ea-9844-2b06da36e590.png">


## Test Plan

1. Run the RNTester app locally on both android and iOS.
2. Open the Alert API screen.
3. Alert examples should be visible and functional in both android and iOS.

Screenshot for both android and iOS screens- 

<img width="688" alt="Screenshot 2020-06-12 at 11 52 21 AM" src="https://user-images.githubusercontent.com/22813027/84471544-2d6d3580-aca3-11ea-9142-5f31a3daaf4e.png">
