### PR TITLE
Workspace name fix

### DIFF
--- a/packages/RNTester/react-native.config.js
+++ b/packages/RNTester/react-native.config.js
@@ -32,7 +32,7 @@ module.exports = {
   reactNativePath: './node_modules/react-native',
   project: {
     ios: {
-      project: './ios/RNTesterPods.xcworkspace',
+      project: './ios/RNTester.xcworkspace',
     },
     android: {
       sourceDir: './android',


### PR DESCRIPTION
## Summary
Fixes #167

Before this, I used to get random errors on every build. I just get a consistent `RCTTurboModule not found` now.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[IOS] [BUG FIX]

