### PR TITLE
Add Imports for iOS examples to TextInput screen

### DIFF
--- a/packages/RNTester/js/examples/TextInput/TextInputExample.js
+++ b/packages/RNTester/js/examples/TextInput/TextInputExample.js
@@ -20,6 +20,8 @@ const {
   StyleSheet,
   Alert,
   Switch,
+  ScrollView, 
+  InputAccessoryView,
 } = require('react-native');
 
 import type {RNTesterExampleModuleItem} from '../../types/RNTesterTypes';

--- a/packages/RNTester/metro.config.js
+++ b/packages/RNTester/metro.config.js
@@ -6,7 +6,7 @@
  */
 
 const path = require('path');
-const reactNativePath = path.resolve('../..');
+const reactNativePath = path.resolve(__dirname, 'node_modules', 'react-native');
 
 module.exports = {
   watchFolders: [path.resolve(__dirname, 'node_modules'), reactNativePath],


### PR DESCRIPTION
Minor import fix for the `TextInputExample.js` 