### PR TITLE
Hide filter pills from the examples screen

### DIFF
--- a/packages/RNTester/js/components/RNTesterExampleContainer.js
+++ b/packages/RNTester/js/components/RNTesterExampleContainer.js
@@ -86,6 +86,7 @@ class RNTesterExampleContainer extends React.Component {
         documentationURL={module.documentationURL}>
         <RNTesterExampleFilter
           testID="example_search"
+          hideFilterPills={true}
           sections={sections}
           filter={filter}
           render={({filteredSections}) =>

--- a/packages/RNTester/js/components/RNTesterExampleFilter.js
+++ b/packages/RNTester/js/components/RNTesterExampleFilter.js
@@ -21,6 +21,7 @@ type Props = {
   sections: Object,
   disableSearch?: boolean,
   testID?: string,
+  hideFilterPills?: boolean,
   ...
 };
 
@@ -98,11 +99,13 @@ class RNTesterExampleFilter extends React.Component<Props, State> {
                 testID={this.props.testID}
                 value={this.state.filter}
               />
-              <RNTesterListFilters
-                onFilterButtonPress={filterLabel =>
-                  this.setState({category: filterLabel})
-                }
-              />
+              {!this.props.hideFilterPills && (
+                <RNTesterListFilters
+                  onFilterButtonPress={(filterLabel) =>
+                    this.setState({category: filterLabel})
+                  }
+                />
+              )}
             </View>
           );
         }}

--- a/packages/RNTester/js/utils/RNTesterList.ios.js
+++ b/packages/RNTester/js/utils/RNTesterList.ios.js
@@ -162,7 +162,7 @@ const ComponentExamples: Array<RNTesterExample> = [
   },
   {
     key: 'TextInputExample',
-    module: require('../examples/TextInput/TextInputExample.ios'),
+    module: require('../examples/TextInput/TextInputExample'),
     category: 'Basic',
     supportsTVOS: true,
   },


### PR DESCRIPTION
## Summary

fixes #178 

The filter pills are implemented in the `RNTesterExampleFilter.js` which is used in both `RNTesterExampleContainer.js` and `RNTesterExampleList.js`. 

This is why the pills are showing on both screens. 

I am using a prop `hideFilterProps` to hide the filters from the `RNTesterExampleContainer.js`. 

## Screenshots

<img width="309" alt="Screenshot 2020-07-29 at 6 34 29 PM" src="https://user-images.githubusercontent.com/22813027/88803488-24d8ac00-d1ca-11ea-9c25-cb7471df9cba.png">

<img width="310" alt="Screenshot 2020-07-29 at 6 34 40 PM" src="https://user-images.githubusercontent.com/22813027/88803501-2c985080-d1ca-11ea-804b-9f00748f8cee.png">

