### PR TITLE
ExampleList and Category Mislabelling fixes.

### DIFF
--- a/RNTester/js/components/RNTesterExampleContainer.js
+++ b/RNTester/js/components/RNTesterExampleContainer.js
@@ -76,6 +76,12 @@ class RNTesterExampleContainer extends React.Component {
       },
     ];
 
+    const content = {
+      data: module.examples,
+      title: 'EXAMPLES',
+      key: 'e',
+    };
+
     return (
       <ExamplePage
         title={module.title}
@@ -87,10 +93,10 @@ class RNTesterExampleContainer extends React.Component {
           testID="example_search"
           page="examples_page"
           hideFilterPills={true}
-          sections={sections}
+          content={content}
           filter={filter}
           render={({filteredSections}) =>
-            filteredSections[0].data.map(this.renderExample)
+            filteredSections.map(this.renderExample)
           }
         />
       </ExamplePage>

--- a/RNTester/js/components/RNTesterExampleFilter.js
+++ b/RNTester/js/components/RNTesterExampleFilter.js
@@ -18,7 +18,7 @@ import {RNTesterThemeContext} from './RNTesterTheme';
 type Props = {
   filter: Function,
   render: Function,
-  sections: Object,
+  content: Object,
   disableSearch?: boolean,
   testID?: string,
   hideFilterPills?: boolean,
@@ -53,10 +53,11 @@ class RNTesterExampleFilter extends React.Component<Props, State> {
       );
     };
 
-    const filteredSections = this.props.sections.map(section => ({
-      ...section,
-      data: section.data.filter(filter),
-    }));
+    // const filteredSections = this.props.sections.map(section => ({
+    //   ...section,
+    //   data: section.data.filter(filter),
+    // }));
+    const filteredSections = this.props.content.data.filter(filter);
 
     return (
       <View style={styles.container}>

--- a/RNTester/js/components/RNTesterExampleFilter.js
+++ b/RNTester/js/components/RNTesterExampleFilter.js
@@ -53,11 +53,12 @@ class RNTesterExampleFilter extends React.Component<Props, State> {
       );
     };
 
+    let filteredSections = this.props.content.data.filter(filter);
 
-    const filteredSections = this.props.content.data.filter(filter);
-
-    if(this.state.filter.trim() !== '' || this.state.category.trim() !== '') {
-      filteredSections = filteredSections.filter(section => section.title !== 'Recently viewed');
+    if (this.state.filter.trim() !== '' || this.state.category.trim() !== '') {
+      filteredSections = filteredSections.filter(
+        section => section.title !== 'Recently viewed',
+      );
     }
 
     return (

--- a/RNTester/js/components/RNTesterExampleList.js
+++ b/RNTester/js/components/RNTesterExampleList.js
@@ -19,6 +19,7 @@ const React = require('react');
 const {
   Platform,
   SectionList,
+  FlatList,
   StyleSheet,
   Text,
   Button,
@@ -82,7 +83,7 @@ class RowComponent extends React.PureComponent<ButtonProps, ButtonState> {
     this.state = {
       active: props.active,
       title: props.item.module.title,
-      key: props.section.key,
+      key: props.key,
     };
   }
 
@@ -114,7 +115,7 @@ class RowComponent extends React.PureComponent<ButtonProps, ButtonState> {
   };
 
   _onPress = () => {
-      if (this.props.onPress) {
+    if (this.props.onPress) {
       this.props.onPress();
       return;
     }
@@ -124,7 +125,7 @@ class RowComponent extends React.PureComponent<ButtonProps, ButtonState> {
     const {item} = this.props;
     return (
       <RNTesterThemeContext.Consumer>
-        {(theme) => {
+        {theme => {
           return (
             <TouchableHighlight
               onShowUnderlay={this.props.onShowUnderlay}
@@ -146,7 +147,7 @@ class RowComponent extends React.PureComponent<ButtonProps, ButtonState> {
 
                   <View style={{flexDirection: 'row', marginBottom: 5}}>
                     <Text style={{color: 'blue'}}>Category: </Text>
-                    <Text>{item.module.category || 'Components/Basic'}</Text>
+                    <Text>{item.category || 'Other'}</Text>
                   </View>
 
                   <Text
@@ -188,7 +189,7 @@ class RowComponent extends React.PureComponent<ButtonProps, ButtonState> {
 
 const renderSectionHeader = ({section}) => (
   <RNTesterThemeContext.Consumer>
-    {(theme) => {
+    {theme => {
       return (
         <Text
           style={[
@@ -213,30 +214,21 @@ class RNTesterExampleList extends React.Component<Props, $FlowFixMeState> {
       (!category || example.category === category) &&
       (!Platform.isTV || example.supportsTVOS);
 
-      const {screen} = this.props; 
-      let sections = []; 
-      if (screen === "component"){ 
-        sections = [
-          {
-            data: this.props.list.ComponentExamples,
-            key: 'Components',
-          }
-        ];
-      } else if (screen === "api") { 
-        sections = [
-          {
-            data: this.props.list.APIExamples,
-            key: 'APIS',
-          }
-        ];
-      } else { 
-        sections = []; 
-      }
-      
+    const {screen} = this.props;
+    let content = {};
+    if (screen === 'component') {
+      content.key = 'Components';
+      content.data = this.props.list.ComponentExamples;
+    } else if (screen === 'api') {
+      content.key = 'APIS';
+      content.data = this.props.list.APIExamples;
+    } else {
+      content.data = [];
+    }
 
     return (
       <RNTesterThemeContext.Consumer>
-        {(theme) => {
+        {theme => {
           return (
             <View
               style={[
@@ -247,18 +239,18 @@ class RNTesterExampleList extends React.Component<Props, $FlowFixMeState> {
               <RNTesterExampleFilter
                 testID="explorer_search"
                 page="components_page"
-                sections={sections}
+                content={content}
                 filter={filter}
                 render={({filteredSections}) => (
-                  <SectionList
-                    sections={filteredSections}
+                  <FlatList
+                    data={filteredSections}
                     renderItem={this._renderItem}
                     keyboardShouldPersistTaps="handled"
                     automaticallyAdjustContentInsets={false}
                     keyboardDismissMode="on-drag"
                     renderSectionHeader={renderSectionHeader}
                     ListFooterComponent={() => (
-                        <View style={{ height: 80 }}></View>
+                      <View style={{height: 80}}></View>
                     )}
                   />
                 )}
@@ -270,20 +262,18 @@ class RNTesterExampleList extends React.Component<Props, $FlowFixMeState> {
     );
   }
 
-  _renderItem = ({item, section, separators}) => {
+  _renderItem = ({item, index, separators}) => {
     let bookmark = this.context;
     return (
       <RowComponent
         item={item}
-        section={section}
-        active={!bookmark.checkBookmark(item.module.title, section.key)}
+        active={!bookmark.checkBookmark(item.module.title, item.key)}
         onNavigate={this.props.onNavigate}
         onShowUnderlay={separators.highlight}
         onHideUnderlay={separators.unhighlight}
       />
     );
   };
-
 
   _handleRowPress(exampleKey: string): void {
     this.props.onNavigate(RNTesterActions.ExampleAction(exampleKey));
@@ -292,7 +282,7 @@ class RNTesterExampleList extends React.Component<Props, $FlowFixMeState> {
 
 const ItemSeparator = ({highlighted}) => (
   <RNTesterThemeContext.Consumer>
-    {(theme) => {
+    {theme => {
       return (
         <View
           style={

--- a/RNTester/js/components/RNTesterExampleList.js
+++ b/RNTester/js/components/RNTesterExampleList.js
@@ -249,8 +249,10 @@ class RNTesterExampleList extends React.Component<Props, $FlowFixMeState> {
     if (key === 'Components') {
       let openedItem = this.state.components[index];
       let componentsCopy = [...this.state.recentComponents];
-      const ind = componentsCopy.findIndex(component => component.key === openedItem.key);
-      if(ind != -1) {
+      const ind = componentsCopy.findIndex(
+        component => component.key === openedItem.key,
+      );
+      if (ind != -1) {
         componentsCopy.splice(ind, 1);
       }
       if (this.state.recentComponents.length >= 5) {
@@ -262,7 +264,7 @@ class RNTesterExampleList extends React.Component<Props, $FlowFixMeState> {
       let openedItem = this.state.api[index];
       let apisCopy = [...this.state.recentApis];
       const ind = apisCopy.findIndex(api => api.key === openedItem.key);
-      if(ind != -1) {
+      if (ind != -1) {
         apisCopy.splice(ind, 1);
       }
       if (this.state.recentApis.length >= 5) {


### PR DESCRIPTION
This PR does 2 things:

- Since we have now turned to a tab-based navigation structure, there's no need for a `SectionList` anymore. We didn't revert from this, and this left an awkward section header at the top of the list. So, I just converted the list to a `FlatList` instead.
- There was some issue with the 'category' labelling, I fixed that.

Tested on iOS, needs android testing. 
 - For testing, just make sure the app is running, and the pill filtering and bookmarking features are working