### PR TITLE
Update StatusBar usecases

### DIFF
--- a/packages/rn-tester/js/examples/StatusBar/StatusBarExample.js
+++ b/packages/rn-tester/js/examples/StatusBar/StatusBarExample.js
@@ -23,7 +23,7 @@ const {
 
 const colors = ['#ff0000', '#00ff00', '#0000ff', 'rgba(0, 0, 0, 0.4)'];
 
-const barStyles = ['default', 'light-content'];
+const barStyles = ['default', 'light-content', 'dark-content'];
 
 const showHideTransitions = ['fade', 'slide'];
 
@@ -122,6 +122,15 @@ class StatusBarStyleExample extends React.Component<{...}, $FlowFixMeState> {
           animated={this.state.animated}
           barStyle={this.state.barStyle}
         />
+        {Platform.OS === 'android' ? (
+          <View style={styles.noteContainer}>
+            <Text>
+              On Android, this will only have an impact on API versions 23 and
+              above.
+            </Text>
+          </View>
+        ) : null}
+
         <TouchableHighlight
           style={styles.wrapper}
           onPress={this._onChangeBarStyle}>
@@ -385,6 +394,29 @@ class StatusBarStaticAndroidExample extends React.Component<{...}> {
             </Text>
           </View>
         </TouchableHighlight>
+        <View style={styles.groupedItems}>
+          <Text style={styles.noteContainer}>
+            These will only have an impact on Android API versions 23 and above.
+          </Text>
+          <TouchableHighlight
+            style={styles.wrapper}
+            onPress={() => {
+              StatusBar.setBarStyle('default', true);
+            }}>
+            <View style={styles.button}>
+              <Text>setBarStyle('default', true)</Text>
+            </View>
+          </TouchableHighlight>
+          <TouchableHighlight
+            style={styles.wrapper}
+            onPress={() => {
+              StatusBar.setBarStyle('dark-content', true);
+            }}>
+            <View style={styles.button}>
+              <Text>setBarStyle('dark-content', true)</Text>
+            </View>
+          </TouchableHighlight>
+        </View>
       </View>
     );
   }
@@ -446,7 +478,6 @@ exports.examples = [
     render(): React.Node {
       return <StatusBarStyleExample />;
     },
-    platform: 'ios',
   },
   {
     title: 'StatusBar network activity indicator',
@@ -518,5 +549,11 @@ const styles = StyleSheet.create({
   },
   modalButton: {
     marginTop: 10,
+  },
+  groupedItems: {
+    padding: 10,
+  },
+  noteContainer: {
+    marginBottom: 15,
   },
 });


### PR DESCRIPTION
## Summary

Updated use cases for StatusBar component/screen.

## Changelog

1. Added `'dark-content'` variant to `barStyle`. (On Android,  API 23+ support it)
2. Modified previous example for testing `barStyle` for Android.
      - Added `noteContainer` style variable for margin.

![WhatsApp Image 2020-08-13 at 4 14 15 PM](https://user-images.githubusercontent.com/47635607/90126328-1faa5e00-dd81-11ea-9701-1cb09d13da0e.jpeg)

3. Added `setBarStyle` example for StatusBar API for Android. 
     - Added `groupedItems` style variable for a little bit of padding to adjust the note (On Android,  API 23+ support it)

![WhatsApp Image 2020-08-13 at 4 16 30 PM](https://user-images.githubusercontent.com/47635607/90126354-2933c600-dd81-11ea-8095-32fc331baefd.jpeg)
