### PR TITLE
New Alert screen

### DIFF
--- a/packages/rn-tester/e2e/__tests__/Alert-test.js
+++ b/packages/rn-tester/e2e/__tests__/Alert-test.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+/* global device, element, by, expect, waitFor */
+const {openExampleWithTitle} = require('../e2e-helpers');
+
+describe('Alert', () => {
+  beforeAll(async () => {
+    await element(by.id('apis-tab')).tap();
+    await element(by.id('explorer_search')).replaceText('Alert');
+    await element(by.label('Alerts')).tap();
+  });
+
+  afterAll(async () => {
+    await element(by.label('Back')).tap();
+  });
+
+  it('should show alert dialog with message and default button', async () => {
+    const alertMessage = 'An external USB drive has been detected!';
+
+    await openExampleWithTitle('Alert with default Button');
+    await element(by.id('alert-with-default-button')).tap();
+    await expect(element(by.text(alertMessage))).toBeVisible();
+    await element(by.text('OK')).tap();
+  });
+
+  it('should show alert dialog with three buttons', async () => {
+    const alertMessage = 'Do you want to save your changes?';
+
+    await openExampleWithTitle('Alert with three Buttons');
+    await element(by.id('alert-with-three-buttons')).tap();
+    await expect(element(by.text(alertMessage))).toBeVisible();
+    await expect(element(by.text('Cancel'))).toBeVisible();
+    await expect(element(by.text('No'))).toBeVisible();
+    await expect(element(by.text('Yes'))).toBeVisible();
+    await element(by.text('Yes')).tap();
+  });
+
+  it('should successfully call the callback on button press', async () => {
+    await openExampleWithTitle('Alert with three Buttons');
+    await element(by.id('alert-with-three-buttons')).tap();
+    await element(by.text('Cancel')).tap();
+    await expect(element(by.text('Log: Cancel Pressed!'))).toBeVisible();
+  });
+});

--- a/packages/rn-tester/js/examples/Alert/AlertExample.js
+++ b/packages/rn-tester/js/examples/Alert/AlertExample.js
@@ -9,119 +9,188 @@
 
 'use strict';
 
-const React = require('react');
-const {
-  Alert,
-  StyleSheet,
-  Text,
-  TouchableHighlight,
-  View,
-} = require('react-native');
+import React, {useState} from 'react';
+import {Alert, StyleSheet, Text, TouchableHighlight, View} from 'react-native';
 
-// corporate ipsum > lorem ipsum
-const alertMessage =
-  'Credibly reintermediate next-generation potentialities after goal-oriented ' +
-  'catalysts for change. Dynamically revolutionize.';
+// Shows log on the screen
+const Log = ({message}) =>
+  message ? (
+    <View style={styles.logContainer}>
+      <Text>
+        <Text style={styles.bold}>Log</Text>: {message}
+      </Text>
+    </View>
+  ) : null;
 
 /**
  * Simple alert examples.
  */
-type Props = $ReadOnly<{||}>;
 
-class SimpleAlertExampleBlock extends React.Component<Props> {
-  render() {
-    return (
-      <View>
-        <TouchableHighlight
-          style={styles.wrapper}
-          onPress={() => Alert.alert('Alert Title', alertMessage)}>
-          <View style={styles.button}>
-            <Text>Alert with message and default button</Text>
-          </View>
-        </TouchableHighlight>
-        <TouchableHighlight
-          style={styles.wrapper}
-          onPress={() =>
-            Alert.alert('Alert Title', alertMessage, [
-              {text: 'OK', onPress: () => console.log('OK Pressed!')},
-            ])
-          }>
-          <View style={styles.button}>
-            <Text>Alert with one button</Text>
-          </View>
-        </TouchableHighlight>
-        <TouchableHighlight
-          style={styles.wrapper}
-          onPress={() =>
-            Alert.alert('Alert Title', alertMessage, [
-              {text: 'Cancel', onPress: () => console.log('Cancel Pressed!')},
-              {text: 'OK', onPress: () => console.log('OK Pressed!')},
-            ])
-          }>
-          <View style={styles.button}>
-            <Text>Alert with two buttons</Text>
-          </View>
-        </TouchableHighlight>
-        <TouchableHighlight
-          style={styles.wrapper}
-          onPress={() =>
-            Alert.alert('Alert Title', null, [
-              {text: 'Foo', onPress: () => console.log('Foo Pressed!')},
-              {text: 'Bar', onPress: () => console.log('Bar Pressed!')},
-              {text: 'Baz', onPress: () => console.log('Baz Pressed!')},
-            ])
-          }>
-          <View style={styles.button}>
-            <Text>Alert with three buttons</Text>
-          </View>
-        </TouchableHighlight>
-        <TouchableHighlight
-          style={styles.wrapper}
-          onPress={() =>
-            Alert.alert(
-              'Foo Title',
-              alertMessage,
-              '..............'.split('').map((dot, index) => ({
-                text: 'Button ' + index,
-                onPress: () => console.log('Pressed ' + index),
-              })),
-            )
-          }>
-          <View style={styles.button}>
-            <Text>Alert with too many buttons</Text>
-          </View>
-        </TouchableHighlight>
-        <TouchableHighlight
-          style={styles.wrapper}
-          onPress={() =>
-            Alert.alert(
-              'Alert Title',
-              null,
-              [{text: 'OK', onPress: () => console.log('OK Pressed!')}],
-              {
-                cancelable: false,
-              },
-            )
-          }>
-          <View style={styles.button}>
-            <Text>Alert that cannot be dismissed</Text>
-          </View>
-        </TouchableHighlight>
-        <TouchableHighlight
-          style={styles.wrapper}
-          onPress={() =>
-            Alert.alert('', alertMessage, [
-              {text: 'OK', onPress: () => console.log('OK Pressed!')},
-            ])
-          }>
-          <View style={styles.button}>
-            <Text>Alert without title</Text>
-          </View>
-        </TouchableHighlight>
-      </View>
-    );
-  }
-}
+const AlertWithDefaultButton = () => {
+  const alertMessage = 'An external USB drive has been detected!';
+
+  return (
+    <View>
+      <TouchableHighlight
+        testID="alert-with-default-button"
+        style={styles.wrapper}
+        onPress={() => Alert.alert('Alert', alertMessage)}>
+        <View style={styles.button}>
+          <Text>Tap to view alert</Text>
+        </View>
+      </TouchableHighlight>
+    </View>
+  );
+};
+
+const AlertWithTwoButtons = () => {
+  const [message, setMessage] = useState('');
+
+  const alertMessage = 'Your subscription has expired!';
+
+  return (
+    <View>
+      <TouchableHighlight
+        style={styles.wrapper}
+        onPress={() =>
+          Alert.alert('Action Required!', alertMessage, [
+            {text: 'Ignore', onPress: () => setMessage('Ignore Pressed!')},
+            {text: 'Renew', onPress: () => setMessage('Renew Pressed!')},
+          ])
+        }>
+        <View style={styles.button}>
+          <Text>Tap to view alert</Text>
+        </View>
+      </TouchableHighlight>
+      <Log message={message} />
+    </View>
+  );
+};
+
+const AlertWithThreeButtons = () => {
+  const [message, setMessage] = useState('');
+
+  const alertMessage = 'Do you want to save your changes?';
+
+  return (
+    <View>
+      <TouchableHighlight
+        testID="alert-with-three-buttons"
+        style={styles.wrapper}
+        onPress={() =>
+          Alert.alert('Unsaved Changes!', alertMessage, [
+            {text: 'Cancel', onPress: () => setMessage('Cancel Pressed!')},
+            {text: 'No', onPress: () => setMessage('No Pressed!')},
+            {text: 'Yes', onPress: () => setMessage('Yes Pressed!')},
+          ])
+        }>
+        <View style={styles.button}>
+          <Text>Tap to view alert</Text>
+        </View>
+      </TouchableHighlight>
+      <Log message={message} />
+    </View>
+  );
+};
+
+const AlertWithManyButtons = () => {
+  const [message, setMessage] = useState('');
+
+  const alertMessage =
+    'Credibly reintermediate next-generation potentialities after goal-oriented ' +
+    'catalysts for change. Dynamically revolutionize.';
+
+  return (
+    <View>
+      <TouchableHighlight
+        style={styles.wrapper}
+        onPress={() =>
+          Alert.alert(
+            'Foo Title',
+            alertMessage,
+            '..............'.split('').map((dot, index) => ({
+              text: 'Button ' + index,
+              onPress: () => setMessage(`Button ${index} Pressed!`),
+            })),
+          )
+        }>
+        <View style={styles.button}>
+          <Text>Tap to view alert</Text>
+        </View>
+      </TouchableHighlight>
+      <Log message={message} />
+    </View>
+  );
+};
+
+const AlertWithCancelableTrue = () => {
+  const [message, setMessage] = useState('');
+
+  const alertMessage = 'Tapping outside this dialog will dismiss this alert.';
+
+  return (
+    <View>
+      <TouchableHighlight
+        style={styles.wrapper}
+        onPress={() =>
+          Alert.alert(
+            'Alert Title',
+            alertMessage,
+            [{text: 'OK', onPress: () => setMessage('OK Pressed!')}],
+            {
+              cancelable: true,
+              onDismiss: () =>
+                setMessage(
+                  'This alert was dismissed by tapping outside of the alert dialog.',
+                ),
+            },
+          )
+        }>
+        <View style={styles.button}>
+          <Text>Tap to view alert</Text>
+        </View>
+      </TouchableHighlight>
+      <Log message={message} />
+    </View>
+  );
+};
+
+const AlertWithStyles = () => {
+  const [message, setMessage] = useState('');
+
+  const alertMessage = 'Look at the button styles!';
+
+  return (
+    <View>
+      <TouchableHighlight
+        style={styles.wrapper}
+        onPress={() =>
+          Alert.alert('Styled Buttons!', alertMessage, [
+            {
+              text: 'Default',
+              onPress: () => setMessage('Default Pressed!'),
+              style: 'default',
+            },
+            {
+              text: 'Cancel',
+              onPress: () => setMessage('Cancel Pressed!'),
+              style: 'cancel',
+            },
+            {
+              text: 'Destructive',
+              onPress: () => setMessage('Destructive Pressed!'),
+              style: 'destructive',
+            },
+          ])
+        }>
+        <View style={styles.button}>
+          <Text>Tap to view alert</Text>
+        </View>
+      </TouchableHighlight>
+      <Log message={message} />
+    </View>
+  );
+};
 
 const styles = StyleSheet.create({
   wrapper: {
@@ -132,19 +201,66 @@ const styles = StyleSheet.create({
     backgroundColor: '#eeeeee',
     padding: 10,
   },
+  logContainer: {
+    paddingVertical: 8,
+    paddingHorizontal: 5,
+  },
+  bold: {
+    fontWeight: 'bold',
+  },
 });
 
-exports.title = 'Alert';
+exports.title = 'Alerts';
 exports.description =
   'Alerts display a concise and informative message ' +
   'and prompt the user to make a decision.';
 exports.examples = [
   {
-    title: 'Alerts',
+    title: 'Alert with default Button',
+    description:
+      "It can be used to show some information to user that doesn't require an action.",
     render(): React.Node {
-      return <SimpleAlertExampleBlock />;
+      return <AlertWithDefaultButton />;
+    },
+  },
+  {
+    title: 'Alert with two Buttons',
+    description: 'It can be used when an action is required from the user.',
+    render(): React.Node {
+      return <AlertWithTwoButtons />;
+    },
+  },
+  {
+    title: 'Alert with three Buttons',
+    description: 'It can be used when there are three possible actions',
+    render(): React.Node {
+      return <AlertWithThreeButtons />;
+    },
+  },
+  {
+    title: 'Alert with many Buttons',
+    platform: 'ios',
+    description: 'It can be used when more than three actions are required.',
+    render(): React.Node {
+      return <AlertWithManyButtons />;
+    },
+  },
+  {
+    title: 'Alert with cancelable={true}',
+    platform: 'android',
+    description:
+      'By passing cancelable={false} prop to alerts on Android, they can be dismissed by tapping outside of the alert box.',
+    render(): React.Node {
+      return <AlertWithCancelableTrue />;
+    },
+  },
+  {
+    title: 'Alert with styles',
+    platform: 'ios',
+    description:
+      "Alert buttons can be styled. There are three button styles - 'default' | 'cancel' | 'destructive'.",
+    render(): React.Node {
+      return <AlertWithStyles />;
     },
   },
 ];
-
-exports.SimpleAlertExampleBlock = SimpleAlertExampleBlock;

--- a/packages/rn-tester/js/examples/Alert/AlertIOSExample.js
+++ b/packages/rn-tester/js/examples/Alert/AlertIOSExample.js
@@ -12,7 +12,7 @@
 
 const React = require('react');
 
-const {SimpleAlertExampleBlock} = require('./AlertExample');
+const {examples: CommonAlertExamples} = require('./AlertExample');
 const {
   StyleSheet,
   View,
@@ -152,15 +152,10 @@ const styles = StyleSheet.create({
 });
 
 exports.framework = 'React';
-exports.title = 'Alert';
+exports.title = 'Alerts';
 exports.description = 'iOS alerts and action sheets';
 exports.examples = [
-  {
-    title: 'Alerts',
-    render(): React.Node {
-      return <SimpleAlertExampleBlock />;
-    },
-  },
+  ...CommonAlertExamples,
   {
     title: 'Prompt Options',
     render(): React.Element<any> {


### PR DESCRIPTION
## Summary

Fixes #15 

## Changelog

- Added new use case for the Alert API as mentioned in #15 
- Wrote each use case in a separate example block to allow searching
- Wrote Detox tests for the Alert Screen


## Test Plan

- Run the RNTester app locally by following [these](https://github.com/MLH-Fellowship/react-native/tree/rntest-pkg/packages/rn-tester) instructions.
- Search for `Alerts` and tap on it


<img width="566" alt="Screenshot 2020-07-07 at 1 29 03 PM" src="https://user-images.githubusercontent.com/22813027/86742553-d5351380-c055-11ea-8cd5-af0484797b8f.png">




