### PR TITLE
Linking API rewrite

### DIFF
--- a/packages/rn-tester/RNTester/Info.plist
+++ b/packages/rn-tester/RNTester/Info.plist
@@ -62,5 +62,10 @@
 	<string>You need to add NSPhotoLibraryUsageDescription key in Info.plist to enable photo library usage, otherwise it is going to *fail silently*!</string>
 	<key>RN_BUNDLE_PREFIX</key>
 	<string>$(RN_BUNDLE_PREFIX)</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>geo</string>
+		<string>tel</string>
+	</array>
 </dict>
 </plist>

--- a/packages/rn-tester/js/examples/Linking/LinkingExample.js
+++ b/packages/rn-tester/js/examples/Linking/LinkingExample.js
@@ -77,8 +77,19 @@ class IntentAndroidExample extends React.Component {
           <OpenURLButton url={'http://www.facebook.com'} />
           <OpenURLButton url={'http://facebook.com'} />
           <OpenURLButton url={'fb://notifications'} />
-          <OpenURLButton url={'geo:37.484847,-122.148386'} />
+          <OpenURLButton
+            url={
+              Platform.OS === 'android'
+                ? 'geo:37.484847,-122.148386'
+                : 'http://maps.apple.com/?ll=37.484847,-122.148386'
+            }
+          />
           <OpenURLButton url={'tel:9876543210'} />
+          <TouchableOpacity onPress={() => Linking.openSettings()}>
+            <View style={[styles.button]}>
+              <Text style={styles.text}>Open settings</Text>
+            </View>
+          </TouchableOpacity>
         </RNTesterBlock>
         {Platform.OS === 'android' && (
           <RNTesterBlock title="Send intents">
@@ -117,8 +128,6 @@ const styles = StyleSheet.create({
 });
 
 exports.title = 'Linking';
-exports.category = 'Basic';
-exports.documentationURL = 'https://reactnative.dev/docs/linking';
 exports.description = 'Shows how to use Linking to open URLs.';
 exports.examples = [
   {


### PR DESCRIPTION
This PR adds/edits some of the use cases for the `Linking` API. 
<img width="380" alt="image" src="https://user-images.githubusercontent.com/29821563/90812500-31957f00-e2f4-11ea-9432-144352da13a6.png">

Example: after pressing Facebook Link: 
<img width="371" alt="image" src="https://user-images.githubusercontent.com/29821563/90812944-de6ffc00-e2f4-11ea-81b4-38976db52c10.png">

- Note that the `fb://notifications` and `open tel:98...` links might not work because the simulator might not have the Facebook app for the former case and the carrier isn't accessible through the simulator for the latter. 
- Android testing needed


